### PR TITLE
DS-473 - [B2B] Even after switching the apps, it shows the interactions of the previous app.

### DIFF
--- a/src/app/dashboard/dashboard-menu/dashboard-menu.component.ts
+++ b/src/app/dashboard/dashboard-menu/dashboard-menu.component.ts
@@ -3,6 +3,7 @@ import { NavigationEnd, Router } from '@angular/router';
 import { distinctUntilChanged, filter } from 'rxjs/operators';
 import { CommonService, GetOptions } from '../../service/common.service';
 import { WorkflowListComponent } from './workflow-list/workflow-list.component';
+import { DashboardService } from 'src/app/dashboard/dashboard.service';
 
 @Component({
   selector: 'odp-dashboard-menu',
@@ -23,7 +24,9 @@ export class DashboardMenuComponent implements OnInit, OnDestroy {
   };
   hideWorkflows: boolean;
   hideInteraction: boolean;
-  constructor(private router: Router, private commonService: CommonService) {
+  constructor(private router: Router, 
+    private commonService: CommonService,
+    private dashboardService: DashboardService) {
     this.subscriptions = {};
   }
 
@@ -35,7 +38,11 @@ export class DashboardMenuComponent implements OnInit, OnDestroy {
       this.setActiveMenu(event.url)
     });
     this.getWorflowItemsCount()
-    // this.wfList.getServices()
+    this.dashboardService.appChanged.subscribe(app => {
+      this.openPanel['workflow']=false;
+      this.openPanel['interaction']=false;
+      this.openPanel['ds']=false;
+    });
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
**Note:** This issue has not been able to replicate in local environment or for a lower number of interactions in our dev instance.

Currently, when we expand the interactions panel and switch to a different app, the interactions from the previous app remain open [View Issue](https://appveen.atlassian.net/browse/DS-473?atlOrigin=eyJpIjoiZDg4NzljYWNhNDIyNGFlZDk3NzM5YzY4NGNiMTg3OTMiLCJwIjoiaiJ9). Our existing logic attempts to redraw the interactions list when the app is switched, but it doesn't function as expected, especially when dealing with a higher count of interactions.

This commit ensures whenever we switch between apps, all currently open panels will be automatically closed. The manual toggling of panels will ensure accurate interaction list is being displayed
